### PR TITLE
Add cache option

### DIFF
--- a/tasks/grunt_output_twig.js
+++ b/tasks/grunt_output_twig.js
@@ -46,7 +46,8 @@ module.exports = function(grunt) {
 				var output,
 					contents = grunt.file.read(src);
 				var template = new Twig.twig({
-					data: contents
+					data: contents,
+					rethrow: true
 				});
 
 				var basepath = path.resolve(path.dirname(src), path.resolve(options.docroot));

--- a/tasks/grunt_output_twig.js
+++ b/tasks/grunt_output_twig.js
@@ -23,8 +23,11 @@ module.exports = function(grunt) {
 		var options = this.options({
 			docroot: false,
 			tmpext: '.html',
-			context: { message : "Hello World" }
-		});	
+			context: { message : "Hello World" },
+			cache: true
+		});
+		
+		Twig.cache(options.cache);
 
 		/**
 		 * TWIG Alterations


### PR DESCRIPTION
When using `grunt-contrib-watch` with `grunt-output-twig` changes made in files included using Twig's `{% include ... %}` syntax were not being output. I added an option that turns off Twig's caching to address this.
